### PR TITLE
feat: add aws-braket app bundle (aws-openondemand#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `apps/aws-braket`: app bundle for the Amazon Braket quantum adapter (form fields:
+  task name, device ARN, OpenQASM 3.0 circuit, shots, results bucket). Completes the
+  ood-apps side of aws-openondemand#28 (braket was a dangling backend with no bundle).
 - Initial OOD application bundles for all 8 AWS compute adapters in the aws-openondemand ecosystem. Each app provides a web UI form researchers use to submit jobs to one of the AWS compute backends.

--- a/apps/aws-braket/form.yml
+++ b/apps/aws-braket/form.yml
@@ -1,0 +1,36 @@
+---
+cluster: "aws-braket"
+form:
+  - job_name
+  - device
+  - circuit
+  - shots
+  - output_bucket
+attributes:
+  job_name:
+    label: "Task Name"
+    value: "ood-braket-task"
+    help: "Name for this quantum task"
+  device:
+    label: "Device ARN"
+    value: "arn:aws:braket:::device/quantum-simulator/amazon/sv1"
+    help: "QPU or managed simulator device ARN (default: SV1 state-vector simulator)"
+  circuit:
+    widget: text_area
+    label: "Circuit (OpenQASM 3.0)"
+    value: |
+      OPENQASM 3.0;
+      qubit[2] q;
+      bit[2] c;
+      h q[0];
+      cnot q[0], q[1];
+      c = measure q;
+    help: "OpenQASM 3.0 or Braket IR circuit to execute"
+  shots:
+    label: "Shots"
+    value: "100"
+    help: "Number of measurement shots"
+  output_bucket:
+    label: "Results S3 Bucket"
+    value: ""
+    help: "S3 bucket (ood-* prefix) where Braket writes task results"

--- a/apps/aws-braket/manifest.yml
+++ b/apps/aws-braket/manifest.yml
@@ -1,0 +1,7 @@
+---
+name: "AWS Braket"
+category: "AWS Compute"
+subcategory: "Quantum"
+role: "batch_connect"
+description: "Submit a quantum task (OpenQASM 3.0 / Braket IR circuit) to an Amazon Braket QPU or managed simulator."
+icon: "fas fa-atom"

--- a/apps/aws-braket/submit.yml.erb
+++ b/apps/aws-braket/submit.yml.erb
@@ -1,0 +1,3 @@
+---
+script:
+  content: "# OOD adapter job"

--- a/apps/aws-braket/template/script.sh.erb
+++ b/apps/aws-braket/template/script.sh.erb
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Job parameters are passed via form fields
+echo "Job submitted via OOD"


### PR DESCRIPTION
Adds the missing `apps/aws-braket` bundle so the Amazon Braket adapter can appear as a portal tile.

Part of **aws-openondemand#28** (braket was a dangling backend — no validation entry, cluster YAML, IAM, or app bundle). This PR is the ood-apps half; the terraform + userdata wiring is in the companion aws-openondemand PR.

## Bundle (mirrors `aws-stepfunctions`)
- `manifest.yml` — name/category/icon (Quantum subcategory)
- `form.yml` — `cluster: aws-braket`; fields: task name, device ARN (defaults to SV1 simulator), OpenQASM 3.0 circuit, shots, results S3 bucket — mapping to the adapter's JobSpec (`circuit`/`device`/`shots`/`output_bucket`/`job_name`)
- `submit.yml.erb`, `template/script.sh.erb` — standard adapter passthrough

Verified: all YAML parses; file structure matches the existing 8 bundles.