### PR TITLE
docs: add house-style status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ood-apps
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![OOD app bundles](https://img.shields.io/badge/Open%20OnDemand-app%20bundles-1f6feb.svg)](https://openondemand.org/)
+
 Open OnDemand (OOD) application bundles for the [aws-openondemand](https://github.com/scttfrdmn/aws-openondemand) ecosystem. Each app provides a web UI form that researchers use to submit jobs to one of the 8 AWS compute adapters.
 
 ## Apps


### PR DESCRIPTION
Adds type-appropriate status badges to the README header, matching the ecosystem house-style level (adapted from the spore-host projects).

- **ood-apps**: License: MIT, OOD app bundles (no CI workflow yet — see #9)

MIT badge reflects the OOD ecosystem license (Open OnDemand itself is MIT). Docs-only.