### PR TITLE
docs: cut v0.1.0 CHANGELOG section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-05-30
+
 ### Added
 - `apps/aws-braket`: app bundle for the Amazon Braket quantum adapter (form fields:
   task name, device ARN, OpenQASM 3.0 circuit, shots, results bucket). Completes the


### PR DESCRIPTION
Converts the initial `[Unreleased]` content into the `[0.1.0]` release section ahead of tagging v0.1.0 (source-only release; this repo has no compiled artifacts).