### PR TITLE
feat: add aws-bedrock app bundle (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `apps/aws-bedrock`: app bundle for the AWS Bedrock batch-inference adapter (form fields:
+  job name, foundation model dropdown, input S3 manifest, output S3 prefix, service role
+  ARN). Completes the ood-apps side of aws-openondemand#11.
+
 ## [0.1.0] - 2026-05-30
 
 ### Added

--- a/apps/aws-bedrock/form.yml
+++ b/apps/aws-bedrock/form.yml
@@ -1,0 +1,36 @@
+---
+cluster: "aws-bedrock"
+form:
+  - job_name
+  - model_id
+  - input_s3
+  - output_s3
+  - role_arn
+attributes:
+  job_name:
+    label: "Job Name"
+    value: "ood-bedrock-batch"
+    help: "Name for this Bedrock batch model-invocation job"
+  model_id:
+    widget: select
+    label: "Foundation Model"
+    options:
+      - ["Claude 3.5 Sonnet v2", "anthropic.claude-3-5-sonnet-20241022-v2:0"]
+      - ["Claude 3.5 Haiku", "anthropic.claude-3-5-haiku-20241022-v1:0"]
+      - ["Claude 3 Opus", "anthropic.claude-3-opus-20240229-v1:0"]
+      - ["Llama 3.1 70B Instruct", "meta.llama3-1-70b-instruct-v1:0"]
+      - ["Titan Text Embeddings v2", "amazon.titan-embed-text-v2:0"]
+      - ["Mistral Large 2", "mistral.mistral-large-2407-v1:0"]
+    help: "Bedrock foundation model to run inference with"
+  input_s3:
+    label: "Input Manifest (S3 URI)"
+    value: ""
+    help: "s3://bucket/input-manifest.jsonl — one {\"recordId\",\"modelInput\"} record per line"
+  output_s3:
+    label: "Output Prefix (S3 URI)"
+    value: ""
+    help: "s3://bucket/output-prefix/ — where Bedrock writes per-record results"
+  role_arn:
+    label: "Service Role ARN"
+    value: ""
+    help: "IAM role Bedrock assumes to read the input manifest and write results"

--- a/apps/aws-bedrock/manifest.yml
+++ b/apps/aws-bedrock/manifest.yml
@@ -1,0 +1,7 @@
+---
+name: "AWS Bedrock"
+category: "AWS Compute"
+subcategory: "Inference"
+role: "batch_connect"
+description: "Run a Bedrock batch model-invocation job over an S3 JSONL manifest — large-scale foundation-model inference (evaluation, annotation, embeddings) with results written to S3."
+icon: "fas fa-robot"

--- a/apps/aws-bedrock/submit.yml.erb
+++ b/apps/aws-bedrock/submit.yml.erb
@@ -1,0 +1,3 @@
+---
+script:
+  content: "# OOD adapter job"

--- a/apps/aws-bedrock/template/script.sh.erb
+++ b/apps/aws-bedrock/template/script.sh.erb
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Job parameters are passed via form fields
+echo "Job submitted via OOD"


### PR DESCRIPTION
Adds `apps/aws-bedrock`, the OOD application bundle for the Bedrock batch-inference backend (aws-openondemand#11). Web form: job name, foundation-model dropdown, input S3 manifest URI, output S3 prefix, service role ARN. Mirrors the `aws-braket` bundle structure (form.yml / manifest.yml / submit.yml.erb / template). Pairs with the new ood-bedrock-adapter and the aws-openondemand wiring (#61).