### PR TITLE
feat: add aws-stepfunctions-genomics pipeline bundle (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `apps/aws-stepfunctions-genomics`: pre-filled app bundle for the reference genomics
+  Step Functions pipeline (preprocess → align → variant-call → annotate), exposing its
+  per-stage inputs (reads/output S3, HealthOmics workflow id, Batch job definition) as form
+  fields. Pairs with the `ood-genomics-pipeline` state machine in aws-openondemand
+  `examples/state-machines/` (aws-openondemand#8).
 - `apps/aws-bedrock`: app bundle for the AWS Bedrock batch-inference adapter (form fields:
   job name, foundation model dropdown, input S3 manifest, output S3 prefix, service role
   ARN). Completes the ood-apps side of aws-openondemand#11.

--- a/apps/aws-stepfunctions-genomics/form.yml
+++ b/apps/aws-stepfunctions-genomics/form.yml
@@ -1,0 +1,34 @@
+---
+cluster: "aws-stepfunctions"
+form:
+  - job_name
+  - state_machine_arn
+  - input_s3
+  - output_s3
+  - align_workflow_id
+  - variant_job_definition
+attributes:
+  job_name:
+    label: "Execution Name"
+    value: "ood-genomics-run"
+    help: "Unique name for this Step Functions execution"
+  state_machine_arn:
+    label: "State Machine ARN"
+    value: ""
+    help: "ARN of the deployed ood-genomics-pipeline state machine (see examples/state-machines)"
+  input_s3:
+    label: "Input reads (S3 URI)"
+    value: ""
+    help: "s3://bucket/raw-reads/ — raw sequence reads to preprocess"
+  output_s3:
+    label: "Output prefix (S3 URI)"
+    value: ""
+    help: "s3://bucket/results/ — where annotated variants are written"
+  align_workflow_id:
+    label: "HealthOmics Workflow ID"
+    value: ""
+    help: "HealthOmics workflow used by the align stage"
+  variant_job_definition:
+    label: "Variant-call Batch Job Definition"
+    value: ""
+    help: "AWS Batch job definition ARN/name for the GPU variant-calling stage"

--- a/apps/aws-stepfunctions-genomics/manifest.yml
+++ b/apps/aws-stepfunctions-genomics/manifest.yml
@@ -1,0 +1,7 @@
+---
+name: "Genomics Pipeline (Step Functions)"
+category: "AWS Compute"
+subcategory: "Workflow"
+role: "batch_connect"
+description: "Run the multi-stage genomics secondary-analysis pipeline (preprocess → align → variant-call → annotate) as one Step Functions execution. Deploy the ood-genomics-pipeline state machine first (see aws-openondemand examples/state-machines)."
+icon: "fas fa-dna"

--- a/apps/aws-stepfunctions-genomics/submit.yml.erb
+++ b/apps/aws-stepfunctions-genomics/submit.yml.erb
@@ -1,0 +1,3 @@
+---
+script:
+  content: "# OOD adapter job"

--- a/apps/aws-stepfunctions-genomics/template/script.sh.erb
+++ b/apps/aws-stepfunctions-genomics/template/script.sh.erb
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Job parameters are passed via form fields
+echo "Job submitted via OOD"


### PR DESCRIPTION
Part of aws-openondemand#8 (Step Functions orchestrator). Adds `apps/aws-stepfunctions-genomics`, a pre-filled OOD app bundle for the reference genomics pipeline (preprocess → align → variant-call → annotate) that surfaces its per-stage inputs as form fields (raw-reads/output S3, HealthOmics workflow id, Batch job definition). Pairs with the `ood-genomics-pipeline` state machine added to aws-openondemand `examples/state-machines/`. Mirrors the existing generic `aws-stepfunctions` bundle structure; YAML validated.